### PR TITLE
Improve help and add tab-completion

### DIFF
--- a/Taskfile.py
+++ b/Taskfile.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+from pathlib import Path
+
+
+def default():
+    task_help()
+
+
+def task_help():
+    """Print documentation of every task"""
+    tasks = {name: obj for name, obj in globals().items() if name.startswith("task_")}
+    maxwidth = max(len(n) - len("task_") for n in tasks)
+    formatter = textwrap.TextWrapper(width=80-maxwidth, subsequent_indent=" " * maxwidth + "\t")
+    for name, obj in tasks.items():
+        trimmed = name[5:]
+        print(trimmed + " "*(maxwidth - len(trimmed)),
+              formatter.fill(inspect.getdoc(obj) or ''), sep="\t")
+
+
+if __name__ == "__main__":
+    if len(argv) == 1:
+        default()
+        exit(0)
+    command = "task_" + argv[1]
+    if command not in globals():
+        print("Command not defined", file=stderr)
+        exit(1)
+    function = globals()[command]
+    function(*argv[2:])

--- a/Taskfile.template
+++ b/Taskfile.template
@@ -2,25 +2,31 @@
 PATH=./node_modules/.bin:$PATH
 
 function install {
+    : "Install dependencies"
     echo "install task not implemented"
 }
 
 function build {
+    : "Build the project"
     echo "build task not implemented"
 }
 
 function start {
+    : "Start the server"
     echo "start task not implemented"
 }
 
 function default {
+    : "Run a default task"
     start
 }
 
 function help {
-    echo "$0 <task> <args>"
-    echo "Tasks:"
-    compgen -A function | cat -n
+	: "Auto-generate list of tasks, including documentation in the form of these noop statements"
+    : "They can span multiple lines if needed"
+	compgen -A function | while read -r name ; do
+		paste <(printf '%s' "$name") <(type "$name" | sed -nEe 's/^[[:space:]]*: ?"(.*)";/\1/p')
+	done
 }
 
 TIMEFORMAT="Task completed in %3lR"

--- a/task-completion.bash
+++ b/task-completion.bash
@@ -1,0 +1,10 @@
+#/bin/bash
+
+_task_completions() {
+    words="$(task help | cut -f 1 | grep -P '\w+')"
+    COMPREPLY=($(compgen -W "$words" "${COMP_WORDS[1]}"))
+}
+
+# Support both `run` and `task` aliases
+complete -F _task_completions run
+complete -F _task_completions task


### PR DESCRIPTION
Adding a little docstring to every task to be printed with the `help` task is very useful. It does work even if no docstring is provided - it just prints the task name. The addition of tab-completion leverages the `help` task to figure out the list of task names as that covers the case where there's a `task:` namespace already.