### PR TITLE
More compatible shebang

### DIFF
--- a/Taskfile.template
+++ b/Taskfile.template
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 PATH=./node_modules/.bin:$PATH
 
 function install {


### PR DESCRIPTION
bash isn't always in /bin/. For example NixOS, the linux distribution I use, doesn't put it there. /usr/bin/env is more likely to exist and will look up bash in PATH